### PR TITLE
Fixing issue with multiple callbacks happening for single text changes

### DIFF
--- a/app/src/main/java/com/ibm/autoformatedittext/AbstractAutoEditText.java
+++ b/app/src/main/java/com/ibm/autoformatedittext/AbstractAutoEditText.java
@@ -49,14 +49,15 @@ public abstract class AbstractAutoEditText extends AppCompatEditText {
         }
 
         CharSequence text = a.getText(R.styleable.AbstractAutoEditText_android_text);
+        a.recycle();
+
         if (text != null && text.length() > 0) {
             setNewText(text);
         }
 
-        a.recycle();
-
-        //Prevents edge case where multiple callbacks are occurring for input from edit texts with suggestions
-        if (getInputType() == (InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE)) {
+        //Prevents edge case where multiple callbacks are occurring for text input type
+        if (getInputType() == (InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE) ||
+                getInputType() == InputType.TYPE_CLASS_TEXT || getInputType() == InputType.TYPE_TEXT_FLAG_MULTI_LINE) {
             setInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
         }
     }

--- a/app/src/main/java/com/ibm/autoformatedittext/AutoFormatEditText.java
+++ b/app/src/main/java/com/ibm/autoformatedittext/AutoFormatEditText.java
@@ -52,7 +52,7 @@ public class AutoFormatEditText extends AbstractAutoEditText {
     @Override
     EditTextState format(String textBefore, String textAfter, int selectionStart, int selectionLength, int replacementLength) {
         //Case where no format exists, so the text can be entered without restriction
-        if (formatter.getFormat() == null || formatter.getFormat().isEmpty()) {
+        if (formatter == null || formatter.getFormat() == null || formatter.getFormat().isEmpty()) {
             return new EditTextState(textAfter, textAfter, selectionStart + replacementLength);
         }
 


### PR DESCRIPTION
Forcing the input type to be visible password/no suggestions if the edit text is in text keyboard mode. These are not supported with the edit text